### PR TITLE
Fixes for static analyzer warnings

### DIFF
--- a/Source/mesh.c
+++ b/Source/mesh.c
@@ -793,7 +793,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	TESSvertex *v, *vPrev;
 	TESShalfEdge *e, *ePrev;
 
-	fPrev = fHead;
 	for( fPrev = fHead ; (f = fPrev->next) != fHead; fPrev = f) {
 		assert( f->prev == fPrev );
 		e = f->anEdge;
@@ -808,7 +807,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	}
 	assert( f->prev == fPrev && f->anEdge == NULL );
 
-	vPrev = vHead;
 	for( vPrev = vHead ; (v = vPrev->next) != vHead; vPrev = v) {
 		assert( v->prev == vPrev );
 		e = v->anEdge;
@@ -823,7 +821,6 @@ void tessMeshCheckMesh( TESSmesh *mesh )
 	}
 	assert( v->prev == vPrev && v->anEdge == NULL );
 
-	ePrev = eHead;
 	for( ePrev = eHead ; (e = ePrev->next) != eHead; ePrev = e) {
 		assert( e->Sym->next == ePrev->Sym );
 		assert( e->Sym != e );


### PR DESCRIPTION
This PR removes redundant assignments to local variables that were flagged by Xcode’s static analyzer as dead stores.
