### PR TITLE
Add a reversed flag to tessAddContour()

### DIFF
--- a/Include/tesselator.h
+++ b/Include/tesselator.h
@@ -118,10 +118,15 @@ enum TessElementType
 // TESS_CONSTRAINED_DELAUNAY_TRIANGULATION
 //   If enabled, the initial triagulation is improved with non-robust Constrained Delayney triangulation.
 //   Disable by default.
+//
+// TESS_REVERSE_CONTOURS
+//   If enabled, tessAddContour() will treat CW contours as CCW and vice versa
+//   Disabled by default.
 
 enum TessOption
 {
 	TESS_CONSTRAINED_DELAUNAY_TRIANGULATION,
+    TESS_REVERSE_CONTOURS
 };
 
 typedef float TESSreal;
@@ -192,7 +197,7 @@ void tessDeleteTess( TESStesselator *tess );
 //   pointer - pointer to the first coordinate of the first vertex in the array.
 //   stride - defines offset in bytes between consecutive vertices.
 //   count - number of vertices in contour.
-void tessAddContour( TESStesselator *tess, int size, const void* pointer, int stride, int count, int reversed );
+void tessAddContour( TESStesselator *tess, int size, const void* pointer, int stride, int count );
 
 // tessSetOption() - Toggles optional tessellation parameters
 // Parameters:

--- a/Include/tesselator.h
+++ b/Include/tesselator.h
@@ -126,7 +126,7 @@ enum TessElementType
 enum TessOption
 {
 	TESS_CONSTRAINED_DELAUNAY_TRIANGULATION,
-    TESS_REVERSE_CONTOURS
+	TESS_REVERSE_CONTOURS
 };
 
 typedef float TESSreal;

--- a/Include/tesselator.h
+++ b/Include/tesselator.h
@@ -192,7 +192,7 @@ void tessDeleteTess( TESStesselator *tess );
 //   pointer - pointer to the first coordinate of the first vertex in the array.
 //   stride - defines offset in bytes between consecutive vertices.
 //   count - number of vertices in contour.
-void tessAddContour( TESStesselator *tess, int size, const void* pointer, int stride, int count );
+void tessAddContour( TESStesselator *tess, int size, const void* pointer, int stride, int count, int reversed );
 
 // tessSetOption() - Toggles optional tessellation parameters
 // Parameters:

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -987,9 +987,9 @@ void tessSetOption( TESStesselator *tess, int option, int value )
 	case TESS_CONSTRAINED_DELAUNAY_TRIANGULATION:
 		tess->processCDT = value > 0 ? 1 : 0;
 		break;
-    case TESS_REVERSE_CONTOURS:
-        tess->reverseContours = value > 0 ? 1 : 0;
-        break;
+	case TESS_REVERSE_CONTOURS:
+		tess->reverseContours = value > 0 ? 1 : 0;
+		break;
 	}
 }
 

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -629,7 +629,7 @@ TESStesselator* tessNewTess( TESSalloc* alloc )
 	tess->bmax[0] = 0;
 	tess->bmax[1] = 0;
 
-    tess->reverseContours = 0;
+	tess->reverseContours = 0;
     
 	tess->windingRule = TESS_WINDING_ODD;
 
@@ -975,8 +975,8 @@ void tessAddContour( TESStesselator *tess, int size, const void* vertices,
 		* vertices in such an order that a CCW contour will add +1 to
 		* the winding number of the region inside the contour.
 		*/
-        e->winding = (tess->reverseContours) ? -1 : 1;
-        e->Sym->winding = (tess->reverseContours) ? 1 : -1;
+        e->winding = tess->reverseContours ? -1 : 1;
+        e->Sym->winding = tess->reverseContours ? 1 : -1;
 	}
 }
 

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -629,6 +629,8 @@ TESStesselator* tessNewTess( TESSalloc* alloc )
 	tess->bmax[0] = 0;
 	tess->bmax[1] = 0;
 
+    tess->reverseContours = 0;
+    
 	tess->windingRule = TESS_WINDING_ODD;
 
 	if (tess->alloc.regionBucketSize < 16)
@@ -911,7 +913,7 @@ void OutputContours( TESStesselator *tess, TESSmesh *mesh, int vertexSize )
 }
 
 void tessAddContour( TESStesselator *tess, int size, const void* vertices,
-					int stride, int numVertices, int reversed )
+					int stride, int numVertices )
 {
 	const unsigned char *src = (const unsigned char*)vertices;
 	TESShalfEdge *e;
@@ -973,8 +975,8 @@ void tessAddContour( TESStesselator *tess, int size, const void* vertices,
 		* vertices in such an order that a CCW contour will add +1 to
 		* the winding number of the region inside the contour.
 		*/
-        e->winding = (reversed) ? -1 : 1;
-        e->Sym->winding = (reversed) ? 1 : -1;
+        e->winding = (tess->reverseContours) ? -1 : 1;
+        e->Sym->winding = (tess->reverseContours) ? 1 : -1;
 	}
 }
 
@@ -985,6 +987,9 @@ void tessSetOption( TESStesselator *tess, int option, int value )
 	case TESS_CONSTRAINED_DELAUNAY_TRIANGULATION:
 		tess->processCDT = value > 0 ? 1 : 0;
 		break;
+    case TESS_REVERSE_CONTOURS:
+        tess->reverseContours = value > 0 ? 1 : 0;
+        break;
 	}
 }
 

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -911,7 +911,7 @@ void OutputContours( TESStesselator *tess, TESSmesh *mesh, int vertexSize )
 }
 
 void tessAddContour( TESStesselator *tess, int size, const void* vertices,
-					int stride, int numVertices )
+					int stride, int numVertices, int reversed )
 {
 	const unsigned char *src = (const unsigned char*)vertices;
 	TESShalfEdge *e;
@@ -973,8 +973,8 @@ void tessAddContour( TESStesselator *tess, int size, const void* vertices,
 		* vertices in such an order that a CCW contour will add +1 to
 		* the winding number of the region inside the contour.
 		*/
-		e->winding = 1;
-		e->Sym->winding = -1;
+        e->winding = (reversed) ? -1 : 1;
+        e->Sym->winding = (reversed) ? 1 : -1;
 	}
 }
 

--- a/Source/tess.h
+++ b/Source/tess.h
@@ -62,7 +62,8 @@ struct TESStesselator {
 	TESSreal bmax[2];
 
 	int processCDT;	/* option to run Constrained Delayney pass. */
-
+    int reverseContours; /* tessAddContour() will treat CCW contours as CW and vice versa */
+    
 	/*** state needed for the line sweep ***/
 	int	windingRule;	/* rule for determining polygon interior */
 

--- a/Source/tess.h
+++ b/Source/tess.h
@@ -62,7 +62,7 @@ struct TESStesselator {
 	TESSreal bmax[2];
 
 	int processCDT;	/* option to run Constrained Delayney pass. */
-    int reverseContours; /* tessAddContour() will treat CCW contours as CW and vice versa */
+	int reverseContours; /* tessAddContour() will treat CCW contours as CW and vice versa */
     
 	/*** state needed for the line sweep ***/
 	int	windingRule;	/* rule for determining polygon interior */


### PR DESCRIPTION
Hi. I added this to simplify contour boolean operations. It enables CW contours to be treated as CCW contours and vice versa.