### PR TITLE
Avoid an unused variable warning

### DIFF
--- a/Source/sweep.c
+++ b/Source/sweep.c
@@ -1135,7 +1135,9 @@ static void InitEdgeDict( TESStesselator *tess )
 static void DoneEdgeDict( TESStesselator *tess )
 {
 	ActiveRegion *reg;
+#ifndef NDEBUG
 	int fixedEdges = 0;
+#endif
 
 	while( (reg = (ActiveRegion *)dictKey( dictMin( tess->dict ))) != NULL ) {
 		/*


### PR DESCRIPTION
This variable is only used in an expression passed to `assert`, which is not evaluated when `NDEBUG`. That can lead to unused-variable warnings or errors depending on build settings.