### PR TITLE
Fix a segfault

### DIFF
--- a/Source/sweep.c
+++ b/Source/sweep.c
@@ -496,7 +496,11 @@ static int CheckForRightSplice( TESStesselator *tess, ActiveRegion *regUp )
 		if( EdgeSign( eUp->Dst, eLo->Org, eUp->Org ) <= 0 ) return FALSE;
 
 		/* eLo->Org appears to be above eUp, so splice eLo->Org into eUp */
-		RegionAbove(regUp)->dirty = regUp->dirty = TRUE;
+		regUp->dirty = TRUE;
+		ActiveRegion* regionAbove = RegionAbove(regUp);
+		if (regionAbove != NULL) {
+			regionAbove->dirty = TRUE;
+		}
 		if (tessMeshSplitEdge( tess->mesh, eUp->Sym ) == NULL) longjmp(tess->env,1);
 		if ( !tessMeshSplice( tess->mesh, eLo->Oprev, eUp ) ) longjmp(tess->env,1);
 	}
@@ -534,7 +538,11 @@ static int CheckForLeftSplice( TESStesselator *tess, ActiveRegion *regUp )
 		if( EdgeSign( eUp->Dst, eLo->Dst, eUp->Org ) < 0 ) return FALSE;
 
 		/* eLo->Dst is above eUp, so splice eLo->Dst into eUp */
-		RegionAbove(regUp)->dirty = regUp->dirty = TRUE;
+		regUp->dirty = TRUE;
+		ActiveRegion* regionAbove = RegionAbove(regUp);
+		if (regionAbove != NULL) {
+			regionAbove->dirty = TRUE;
+		}
 		e = tessMeshSplitEdge( tess->mesh, eUp );
 		if (e == NULL) longjmp(tess->env,1);
 		if ( !tessMeshSplice( tess->mesh, eLo->Sym, e ) ) longjmp(tess->env,1);

--- a/Tests/libtess2_test.cc
+++ b/Tests/libtess2_test.cc
@@ -181,4 +181,19 @@ TEST(Libtess2Test, SingularityQuad) {
   EXPECT_EQ(tessGetElementCount(tess), 0);
 }
 
+TEST(Libtess2Test, DegenerateQuad) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  // A quad that's extremely close to a giant triangle, with an extra sliver.
+  // Caused a segfault previously.
+  AddPolyline(tess, {{0.f, 3.40282347e+38f},
+                     {0.64113313f, -1.f},
+                     {-0.f, -0.f},
+                     {-3.40282347e+38f, 1.f}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 2);
+}
+
 }  // namespace


### PR DESCRIPTION
This is from an example found in downstream fuzz-testing. It seems like `RegionAbove(regUp)` can be a null pointer in some degenerate cases, probably where a segment is indistinguishable from vertical.