### PR TITLE
Guard against NaN

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,12 +24,13 @@ cc_library(
         "Source/tess.c",
         "Source/tess.h",
     ],
-    includes = ["Include/"],
     hdrs = ["Include/tesselator.h"],
+    includes = ["Include/"],
 )
 
 cc_test(
     name = "libtess2_test",
+    size = "small",
     srcs = ["Tests/libtess2_test.cc"],
     deps = [
         ":libtess2",

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -938,7 +938,11 @@ void tessAddContour( TESStesselator *tess, int size, const void* vertices,
 	{
 		const TESSreal* coords = (const TESSreal*)src;
 		src += stride;
-
+		if (isnan(coords[0]) || isnan(coords[1]) || (size > 2 && isnan(coords[2]))) {
+			// "Out of memory" isn't quite right, but give up and bail out
+			tess->outOfMemory = 1;
+			return;
+		}
 		if( e == NULL ) {
 			/* Make a self-loop (one vertex, one edge). */
 			e = tessMeshMakeEdge( tess->mesh );

--- a/Tests/libtess2_test.cc
+++ b/Tests/libtess2_test.cc
@@ -1,8 +1,9 @@
+#include <cmath>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 
 #include "gtest/gtest.h"
-
 #include "tesselator.h"
 
 namespace {
@@ -62,6 +63,11 @@ void AddPolygonWithHole(TESStesselator* tess) {
                  kComponentCount * sizeof(TESSreal), inner_hole.size());
 }
 
+void AddPolyline(TESStesselator* tess, const std::vector<Vector2f>& polyline) {
+  tessAddContour(tess, kComponentCount, polyline.data(),
+                 kComponentCount * sizeof(TESSreal), polyline.size());
+}
+
 // Tests that tessellation succeeds when the default allocator is used.
 TEST(Libtess2Test, DefaultAllocSuccess) {
   TESStesselator* tess = tessNewTess(nullptr);
@@ -105,6 +111,87 @@ TEST(Libtess2Test, CustomAllocSuccess) {
   EXPECT_EQ(tessGetElementCount(tess), 8);
 
   tessDeleteTess(tess);
+}
+
+TEST(Libtess2Test, EmptyPolyline) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 0);
+}
+
+TEST(Libtess2Test, SingleLine) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {{0, 0}, {0, 1}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 0);
+}
+
+TEST(Libtess2Test, SingleTriangle) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {{0, 0}, {0, 1}, {1, 0}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 1);
+}
+
+TEST(Libtess2Test, UnitQuad) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {{0, 0}, {0, 1}, {1, 1}, {1, 0}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 2);
+}
+
+TEST(Libtess2Test, FloatOverflowQuad) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+
+  constexpr float kFloatMin = std::numeric_limits<float>::min();
+  constexpr float kFloatMax = std::numeric_limits<float>::max();
+
+  // Add the polygon and tessellate it.
+  AddPolyline(tess, {{kFloatMin, kFloatMin},
+                     {kFloatMin, kFloatMax},
+                     {kFloatMax, kFloatMax},
+                     {kFloatMax, kFloatMin}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 0);
+}
+
+TEST(Libtess2Test, SingularityQuad) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {{0, 0}, {0, 0}, {0, 0}, {0, 0}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 0);
+}
+
+TEST(Libtess2Test, NanQuad) {
+  TESStesselator* tess = tessNewTess(nullptr);
+  ASSERT_NE(tess, nullptr);
+  AddPolyline(tess, {{std::nan(""), std::nan("")},
+                     {std::nan(""), std::nan("")},
+                     {std::nan(""), std::nan("")},
+                     {std::nan(""), std::nan("")}});
+  EXPECT_EQ(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetElementCount(tess), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Currently this causes an assertion failure crash if assertions are enabled due to an assertion about the ordering of a sorted data-structure. The set of all floats does not have a complete well-defined order if NaN is permitted.