### PR TITLE
Make headers available under libtess2/ for Bazel consumers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,9 @@ cc_library(
         "Source/tess.h",
     ],
     hdrs = ["Include/tesselator.h"],
+    include_prefix = "libtess2",
     includes = ["Include/"],
+    strip_include_prefix = "Include",
 )
 
 cc_test(


### PR DESCRIPTION
This makes it a little easier to depend on for projects following that convention, without having to rework the directory structure here.