### PR TITLE
Use isnan instead of isnanf

### DIFF
--- a/Source/geom.c
+++ b/Source/geom.c
@@ -87,7 +87,7 @@ TESSreal tesedgeSign( TESSvertex *u, TESSvertex *v, TESSvertex *w )
 
 	if( gapL + gapR > 0 ) {
 		TESSreal result = (v->t - w->t) * gapL + (v->t - u->t) * gapR;
-		return isnanf(result) ? 0 : result;
+		return isnan(result) ? 0 : result;
 	}
 	/* vertical line */
 	return 0;

--- a/Source/tess.c
+++ b/Source/tess.c
@@ -942,7 +942,7 @@ void tessAddContour( TESStesselator *tess, int size, const void* vertices,
 	{
 		const TESSreal* coords = (const TESSreal*)src;
 		src += stride;
-		if (isnanf(coords[0]) || isnanf(coords[1]) || (size > 2 && isnanf(coords[2]))) {
+		if (isnan(coords[0]) || isnan(coords[1]) || (size > 2 && isnan(coords[2]))) {
 			// "Out of memory" isn't quite right, but give up and bail out
 			tess->outOfMemory = 1;
 			return;


### PR DESCRIPTION
The manpage for math.h notes:
https://linux.die.net/man/3/isnanf

"Note that these functions are obsolete. C99 defines macros isfinite(), isinf(), and isnan() (for all types) replacing them."

The C standard documentation here omits isnanf:
https://en.cppreference.com/w/c/header/math

And it seems that many downstream implementations (especially ones for platforms other than Linux) leave it out.