### PR TITLE
Also run test CI in opt-mode

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -16,3 +16,6 @@ jobs:
 
     - name: Test
       run: bazel test --test_output=errors --keep_going //...
+
+    - name: Opt-Mode Test
+      run: bazel test -c opt --test_output=errors --keep_going //...


### PR DESCRIPTION
Some of the crashes I'm trying to track down only occur with optimizations turned on. Others fail differently in opt-mode (due to compiled-out assertions).