### PR TITLE
Another fix for #22

### DIFF
--- a/Source/geom.h
+++ b/Source/geom.h
@@ -48,7 +48,12 @@
 #endif
 
 #define EdgeEval(u,v,w)	tesedgeEval(u,v,w)
-#define EdgeSign(u,v,w)	tesedgeSign(u,v,w)
+
+/* EdgeSign used to call tesedgeSign(), which is a cheaper version of tesedgeEval(), but should return the same sign.
+* This does not seem to be the case if the x coordinates are almost 0. Always using tesedgeEval() fixes this discrepancy.
+* See https://github.com/memononen/libtess2/issues/22 for example data that triggers the issue.
+*/
+#define EdgeSign(u,v,w)	tesedgeEval(u,v,w)
 
 /* Versions of VertLeq, EdgeSign, EdgeEval with s and t transposed. */
 


### PR DESCRIPTION
tesedgeSign() does not evaluate to the same sign as tesedgeEval() when the x-coordinates are almost zero. In the test data we had values like -1.70990830e-08f, -8.38190317e-09f, -3.35276112e-10f.

The fix is to always use tesedgeEval() so that we have consistent signs.

This is slight perf degrade, but the code written in '94 tried really hard to avoid one floating point division, and I think we can handle with that today.