### PR TITLE
Replace tess->outOfMemory with a tess->status enum

### DIFF
--- a/Include/tesselator.h
+++ b/Include/tesselator.h
@@ -222,7 +222,8 @@ void tessSetOption( TESStesselator *tess, int option, int value );
 //   vertexSize - defines the number of coordinates in tesselation result vertex, must be 2 or 3.
 //   normal - defines the normal of the input contours, of null the normal is calculated automatically.
 // Returns:
-//   1 if succeed, 0 if failed.
+//   1 if succeed, 0 if failed (tessGetStatus can be used after to get a more
+//   specific failure status)
 int tessTesselate( TESStesselator *tess, int windingRule, int elementType, int polySize, int vertexSize, const TESSreal* normal );
 
 // tessGetVertexCount() - Returns number of vertices in the tesselated output.
@@ -242,6 +243,18 @@ int tessGetElementCount( TESStesselator *tess );
 
 // tessGetElements() - Returns pointer to the first element.
 const TESSindex* tessGetElements( TESStesselator *tess );
+
+typedef enum TESSstatus {
+  TESS_STATUS_OK,
+  TESS_STATUS_OUT_OF_MEMORY,
+  TESS_STATUS_INVALID_INPUT
+} TESSstatus;
+
+// Return the success or failure status. If tessTesselate fails (or will fail,
+// e.g. after invalid data is passed to tessAddContour), this can indicate
+// more specifically why. It can also be checked after tessAddContour to
+// see whether to bail out early.
+TESSstatus tessGetStatus( TESStesselator *tess );
 
 #ifdef __cplusplus
 };

--- a/Source/tess.h
+++ b/Source/tess.h
@@ -43,14 +43,12 @@
 extern "C" {
 #endif
 
-//typedef struct TESStesselator TESStesselator;
-
 struct TESStesselator {
 
 	/*** state needed for collecting the input data ***/
 	TESSmesh	*mesh;		/* stores the input contours, and eventually
 						the tessellation itself */
-	int outOfMemory;
+	TESSstatus status;
 
 	/*** state needed for projecting onto the sweep plane ***/
 

--- a/Tests/libtess2_test.cc
+++ b/Tests/libtess2_test.cc
@@ -158,6 +158,22 @@ TEST_F(Libtess2Test, UnitQuad) {
   EXPECT_EQ(tessGetElementCount(tess), 2);
 }
 
+TEST_F(Libtess2Test, GetStatusInvalidInput) {
+  AddPolyline(tess, {{-2e+37f, 0.f}, {0, 5}, {1e37f, -5}});
+  EXPECT_EQ(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetStatus(tess), TESS_STATUS_INVALID_INPUT);
+}
+
+TEST_F(Libtess2Test, GetStatusOk) {
+  AddPolyline(tess, {{0, 0}, {0, 1}, {1, 1}, {1, 0}});
+  EXPECT_NE(tessTesselate(tess, TESS_WINDING_POSITIVE, TESS_POLYGONS,
+                          kNumTriangleVertices, kComponentCount, nullptr),
+            0);
+  EXPECT_EQ(tessGetStatus(tess), TESS_STATUS_OK);
+}
+
 TEST_F(Libtess2Test, FloatOverflowQuad) {
   constexpr float kFloatMin = std::numeric_limits<float>::min();
   constexpr float kFloatMax = std::numeric_limits<float>::max();


### PR DESCRIPTION
This is still not part of the public API.

Change the failure value for "input is out of range" to something other than "out of memory".