### PR TITLE
Very slightly loosen some asserts by adding FLT_MIN tolerance

### DIFF
--- a/Source/sweep.c
+++ b/Source/sweep.c
@@ -30,6 +30,7 @@
 */
 
 #include <assert.h>
+#include <float.h>
 #include <stddef.h>
 #include <setjmp.h>		/* longjmp */
 
@@ -605,11 +606,14 @@ static int CheckForIntersect( TESStesselator *tess, ActiveRegion *regUp )
 	DebugEvent( tess );
 
 	tesedgeIntersect( dstUp, orgUp, dstLo, orgLo, &isect );
-	/* The following properties are guaranteed: */
-	assert( MIN( orgUp->t, dstUp->t ) <= isect.t );
-	assert( isect.t <= MAX( orgLo->t, dstLo->t ));
-	assert( MIN( dstLo->s, dstUp->s ) <= isect.s );
-	assert( isect.s <= MAX( orgLo->s, orgUp->s ));
+	/*
+	 * The following properties are guaranteed (with a little wiggle-room to
+	 * account for loss of precision if the values are subnormal.)
+	 */
+	assert( MIN( orgUp->t, dstUp->t ) <= isect.t + FLT_MIN);
+	assert( isect.t <= MAX( orgLo->t, dstLo->t ) + FLT_MIN);
+	assert( MIN( dstLo->s, dstUp->s ) <= isect.s + FLT_MIN);
+	assert( isect.s <= MAX( orgLo->s, orgUp->s ) + FLT_MIN);
 
 	if( VertLeq( &isect, tess->event )) {
 		/* The intersection point lies slightly to the left of the sweep line,


### PR DESCRIPTION
Found an example with fuzz-testing where this assertion failed with extremely small values. For example, the first assert failed with:

`orgUp->t: -0x1.ffep-138 dstUp->t: 0x0p+0 isect.t: -0x1p-137`

(values in hex float)

So that's with `isect.t` an extremely close-to-zero negative value, `dstUp->t` as exactly 0, but `orgUp->t` as just a hair smaller.