### PR TITLE
Fix some compilation warnings

### DIFF
--- a/Source/geom.c
+++ b/Source/geom.c
@@ -197,7 +197,7 @@ double Interpolate( double a, double x, double b, double y)
 
 #endif
 
-#define Swap(a,b)	if (1) { TESSvertex *t = a; a = b; b = t; } else
+#define Swap(a,b)	do { TESSvertex *t = a; a = b; b = t; } while (0)
 
 void tesedgeIntersect( TESSvertex *o1, TESSvertex *d1,
 					  TESSvertex *o2, TESSvertex *d2,

--- a/Source/mesh.c
+++ b/Source/mesh.c
@@ -750,6 +750,8 @@ int tessMeshMergeConvexFaces( TESSmesh *mesh, int maxVertsPerFace )
 
 void tessMeshFlipEdge( TESSmesh *mesh, TESShalfEdge *edge )
 {
+	TESS_NOTUSED(mesh);
+
 	TESShalfEdge *a0 = edge;
 	TESShalfEdge *a1 = a0->Lnext;
 	TESShalfEdge *a2 = a1->Lnext;

--- a/Source/priorityq.c
+++ b/Source/priorityq.c
@@ -334,7 +334,7 @@ void pqDeletePriorityQ( TESSalloc* alloc, PriorityQ *pq )
 
 #define LT(x,y)     (! LEQ(y,x))
 #define GT(x,y)     (! LEQ(x,y))
-#define Swap(a,b)   if(1){PQkey *tmp = *a; *a = *b; *b = tmp;}else
+#define Swap(a,b)   do { PQkey *tmp = *a; *a = *b; *b = tmp; } while (0)
 
 /* really tessPqSortInit */
 int pqInit( TESSalloc* alloc, PriorityQ *pq )


### PR DESCRIPTION
When I compile the library with warnings enabled, I get some unpleasant output during the build stage:

```c
Source/geom.c: In function ‘tesedgeIntersect’:
Source/geom.c:220:50: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  220 |         if( ! VertLeq( o1, d1 )) { Swap( o1, d1 ); }
      |                                                  ^
Source/geom.c:221:50: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  221 |         if( ! VertLeq( o2, d2 )) { Swap( o2, d2 ); }
      |                                                  ^
Source/geom.c:222:50: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  222 |         if( ! VertLeq( o1, o2 )) { Swap( o1, o2 ); Swap( d1, d2 ); }
      |                                                  ^
Source/geom.c:222:66: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  222 |         if( ! VertLeq( o1, o2 )) { Swap( o1, o2 ); Swap( d1, d2 ); }
      |                                                                  ^
Source/geom.c:243:51: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  243 |         if( ! TransLeq( o1, d1 )) { Swap( o1, d1 ); }
      |                                                   ^
Source/geom.c:244:51: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  244 |         if( ! TransLeq( o2, d2 )) { Swap( o2, d2 ); }
      |                                                   ^
Source/geom.c:245:51: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  245 |         if( ! TransLeq( o1, o2 )) { Swap( o1, o2 ); Swap( d1, d2 ); }
      |                                                   ^
Source/geom.c:245:67: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  245 |         if( ! TransLeq( o1, o2 )) { Swap( o1, o2 ); Swap( d1, d2 ); }
      |                                                                   ^
Source/mesh.c: In function ‘tessMeshFlipEdge’:
Source/mesh.c:751:34: warning: unused parameter ‘mesh’ [-Wunused-parameter]
  751 | void tessMeshFlipEdge( TESSmesh *mesh, TESShalfEdge *edge )
      |                        ~~~~~~~~~~^~~~
Source/priorityq.c: In function ‘pqInit’:
Source/priorityq.c:385:45: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  385 |                                 Swap( i, j );
      |                                             ^
Source/priorityq.c:387:37: warning: suggest braces around empty body in an ‘else’ statement [-Wempty-body]
  387 |                         Swap( i, j ); /* Undo last swap */
      |
```

I provide a little patch to fix that if you're interested, otherwise never mind ;)